### PR TITLE
remove the import line that breaks the cli

### DIFF
--- a/src/quartic/__init__.py
+++ b/src/quartic/__init__.py
@@ -1,4 +1,2 @@
 from quartic.common.step import step
 from quartic.common.dataset import writer
-
-from .ipython_magics import load_ipython_extension, unload_ipython_extension


### PR DESCRIPTION
Changing this back to the way that it was, with appropriate change in ipython config in Jupyter image that we deploy.